### PR TITLE
add: Unread counts in the feed list

### DIFF
--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -15,7 +15,7 @@ pub struct Feed {
     pub link: String,
     pub favicon_url: Option<String>,
     pub last_updated: DateTime<Utc>,
-    pub unread_count: i64,
+    pub unread_count: u16,
 }
 
 impl TryFrom<Row> for Feed {
@@ -35,7 +35,7 @@ impl TryFrom<Row> for Feed {
                 .map(|s| s.to_owned()),
             last_updated: DateTime::from_str(row.read::<&str, _>("last_updated"))
                 .map_err(|e: chrono::ParseError| RepositoryError::Deserialization(e.into()))?,
-            unread_count: row.read::<Option<i64>, _>("unread_count").unwrap_or_else(|| 0),
+            unread_count: row.read::<i64, _>("unread_count").clamp(0, u16::MAX as i64) as u16,
         })
     }
 }

--- a/src/models/feed.rs
+++ b/src/models/feed.rs
@@ -15,6 +15,7 @@ pub struct Feed {
     pub link: String,
     pub favicon_url: Option<String>,
     pub last_updated: DateTime<Utc>,
+    pub unread_count: i64,
 }
 
 impl TryFrom<Row> for Feed {
@@ -34,6 +35,7 @@ impl TryFrom<Row> for Feed {
                 .map(|s| s.to_owned()),
             last_updated: DateTime::from_str(row.read::<&str, _>("last_updated"))
                 .map_err(|e: chrono::ParseError| RepositoryError::Deserialization(e.into()))?,
+            unread_count: row.read::<Option<i64>, _>("unread_count").unwrap_or_else(|| 0),
         })
     }
 }

--- a/src/services/feed/feed_service_impl.rs
+++ b/src/services/feed/feed_service_impl.rs
@@ -255,6 +255,7 @@ where
             url: feed_url.into(),
             favicon_url: None,
             last_updated: DateTime::default(),
+            unread_count: 0,
         };
 
         self.feed_repository.add_feed(feed).await?;

--- a/static/css/dark_theme.css
+++ b/static/css/dark_theme.css
@@ -19,3 +19,8 @@ a {
   background-color: #FFF;
   color: #000;
 }
+
+.unread-count {
+    background-color: #FFF;
+    color: #000;
+  }

--- a/static/css/general.css
+++ b/static/css/general.css
@@ -133,7 +133,5 @@ sub {
   padding: 2px 8px;
   border-radius: 12px;
   margin-left: 8px;
-  background-color: #808080;
-  color: white;
   vertical-align: middle;
 }

--- a/static/css/general.css
+++ b/static/css/general.css
@@ -125,3 +125,15 @@ sub {
   text-align: center;
   padding: 40px;
 }
+
+.unread-count {
+  display: inline-block;
+  font-size: 0.8em;
+  font-weight: bold;
+  padding: 2px 8px;
+  border-radius: 12px;
+  margin-left: 8px;
+  background-color: #808080;
+  color: white;
+  vertical-align: middle;
+}

--- a/static/css/light_theme.css
+++ b/static/css/light_theme.css
@@ -19,3 +19,8 @@ a {
   background-color: #000;
   color: #FFF;
 }
+
+.unread-count {
+    background-color: #000;
+    color: #FFF;
+  }

--- a/templates/feed_list.html
+++ b/templates/feed_list.html
@@ -22,7 +22,12 @@
                 <div id="body" class="list">
                     {% for feed in context.feeds %}
                     <a href="feed/{{ feed.id }}">
-                        <h3> {{ feed.title }} </h3>
+                        <h3> 
+                            {{ feed.title }} 
+                            {% if feed.unread_count > 0 %}
+                            <span class="unread-count">{{ feed.unread_count }}</span>
+                            {% endif %}
+                        </h3>
                         <hr/>
                     </a>
                     {% endfor %}

--- a/templates/feed_list.html
+++ b/templates/feed_list.html
@@ -21,15 +21,17 @@
                 </div>
                 <div id="body" class="list">
                     {% for feed in context.feeds %}
-                    <a href="feed/{{ feed.id }}">
-                        <h3> 
-                            {{ feed.title }} 
-                            {% if feed.unread_count > 0 %}
-                            <span class="unread-count">{{ feed.unread_count }}</span>
-                            {% endif %}
-                        </h3>
-                        <hr/>
-                    </a>
+                        <a href="feed/{{ feed.id }}">
+                            <div style="display: flex; justify-content: space-between; padding: 0 5px;">
+                                <h3>{{ feed.title }}</h3>
+                                <div>
+                                    {% if feed.unread_count > 0 %}
+                                        <span class="unread-count">{{ feed.unread_count }}</span>
+                                    {% endif %}
+                                </div>
+                            </div>
+                            <hr/>
+                        </a>
                     {% endfor %}
                 </div>
             </div>


### PR DESCRIPTION
Unread counts in the feed list was a missing feature for me. So, I have added basic support for that here. I hope you find it useful. It looks like this:
<img width="655" alt="unread-count-added" src="https://github.com/user-attachments/assets/8eec64fc-8cbd-411d-a212-130f375543ce" />

Right now, the counts are not shown as soon as the feed is added (once it is redirected to the homepage after successfully adding a feed). You have to click on a feed and return to the home page. I couldn't figure out how to correct this.

BTW, I'm new to Rust development. So please review and give feedback if you have any suggestions to make it align with Rust best practices.

